### PR TITLE
'Test connection' + running queries in background thread

### DIFF
--- a/src/main/java/com/appian/intellij/k/actions/KActionUtil.java
+++ b/src/main/java/com/appian/intellij/k/actions/KActionUtil.java
@@ -25,6 +25,8 @@ import com.intellij.execution.ui.RunContentManager;
 import com.intellij.execution.ui.actions.CloseAction;
 import com.intellij.ide.structureView.StructureViewTreeElement;
 import com.intellij.ide.util.treeView.AbstractTreeNode;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -34,6 +36,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.pom.Navigatable;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -155,5 +158,13 @@ class KActionUtil {
     return Optional.ofNullable(getElementAtCaret(event).flatMap(KUtil::getTopLevelFunctionDefinition)
         .orElseGet(
             () -> getNavigableSelectionElement(event).flatMap(KUtil::getTopLevelFunctionDefinition).orElse(null)));
+  }
+
+  static void showInformationNotification(Project project, String message) {
+    String displayId = "Q Plugin Notifications";
+    NotificationGroup group = Optional.ofNullable(NotificationGroup.findRegisteredGroup(displayId))
+        .orElseGet(() -> NotificationGroup.toolWindowGroup(displayId, ToolWindowId.RUN));
+
+    group.createNotification(message, NotificationType.INFORMATION).notify(project);
   }
 }

--- a/src/main/java/com/appian/intellij/k/actions/KDefineElementAction.java
+++ b/src/main/java/com/appian/intellij/k/actions/KDefineElementAction.java
@@ -71,7 +71,7 @@ public class KDefineElementAction extends AnAction {
       PsiElement copy = element.copy();
       ((LeafPsiElement)copy.getFirstChild().getFirstChild().getFirstChild()).replaceWithText(getFqnOrName(userId));
 
-      processHandler.execute(console, copy.getText());
+      processHandler.execute(project, console, copy.getText());
     }
   }
 }

--- a/src/main/java/com/appian/intellij/k/actions/KRunSelectionAction.java
+++ b/src/main/java/com/appian/intellij/k/actions/KRunSelectionAction.java
@@ -55,7 +55,7 @@ public class KRunSelectionAction extends AnAction {
     if (processHandler == null) { // can't really happen, but...
       console.print("Internal error, please close the console and try again", ERROR_OUTPUT);
     } else {
-      processHandler.execute(console, q);
+      processHandler.execute(project, console, q);
     }
   }
 }

--- a/src/main/java/com/appian/intellij/k/actions/KServerProcessHandler.java
+++ b/src/main/java/com/appian/intellij/k/actions/KServerProcessHandler.java
@@ -77,7 +77,7 @@ public class KServerProcessHandler extends ProcessHandler {
         .findFirst()
         .orElseThrow(() -> new RuntimeException(
             "Connection details for server " + serverId + " not found, please close console and try again"));
-    return new c(spec.getHost(), spec.getPort(), spec.getUser() + ":" + spec.getPassword(), spec.useTLS());
+    return spec.createConnection();
   }
 
   void execute(ConsoleView console, String q) {

--- a/src/main/java/com/appian/intellij/k/settings/KServerDialog.form
+++ b/src/main/java/com/appian/intellij/k/settings/KServerDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.appian.intellij.k.settings.KServerDialog">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="6" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="6" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="622" height="185"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="c444a" class="javax.swing.JTextField" binding="nameText">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -46,7 +46,7 @@
       </component>
       <component id="40b74" class="javax.swing.JTextField" binding="userText">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -54,7 +54,7 @@
       </component>
       <component id="7ce96" class="javax.swing.JTextField" binding="hostText">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -70,7 +70,7 @@
       </component>
       <component id="9547" class="javax.swing.JPasswordField" binding="passwordField">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="3" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -78,7 +78,7 @@
       </component>
       <component id="e6a46" class="javax.swing.JCheckBox" binding="useTLSCheckBox" default-binding="true">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Use TLS"/>
@@ -86,7 +86,7 @@
       </component>
       <component id="d446b" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Port:"/>
@@ -94,16 +94,32 @@
       </component>
       <component id="e3d08" class="javax.swing.JFormattedTextField" binding="portText" custom-create="true">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="4" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="50" height="-1"/>
             <preferred-size width="50" height="-1"/>
           </grid>
         </constraints>
         <properties/>
       </component>
+      <component id="b83e9" class="javax.swing.JButton" binding="testConnectionButton">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Test Connection"/>
+        </properties>
+      </component>
+      <component id="621e9" class="javax.swing.JLabel" binding="messageLabel">
+        <constraints>
+          <grid row="5" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="2" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=" "/>
+        </properties>
+      </component>
       <vspacer id="399eb">
         <constraints>
-          <grid row="5" column="2" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
     </children>

--- a/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
+++ b/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
@@ -38,7 +38,7 @@ public class KServerDialog extends DialogWrapper {
   private JButton testConnectionButton;
   private JLabel messageLabel;
 
-  private final static Color darkGreem     = new JBColor(new Color(0, 155, 0), Color.green);
+  private final static Color DARK_GREEN = new JBColor(new Color(0, 155, 0), Color.green);
 
   public KServerDialog(Function<String,ValidationInfo> nameValidator) {
     super(null);
@@ -60,7 +60,7 @@ public class KServerDialog extends DialogWrapper {
       panel.setCursor(Cursor.getPredefinedCursor(WAIT_CURSOR));
       c connection = getConnectionSpec().createConnection();
       try {
-        messageLabel.setForeground(darkGreem);
+        messageLabel.setForeground(DARK_GREEN);
         messageLabel.setText("Success");
       }
       finally {

--- a/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
+++ b/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
@@ -1,11 +1,18 @@
 package com.appian.intellij.k.settings;
 
+import static java.awt.Cursor.WAIT_CURSOR;
+
+import java.awt.Color;
+import java.awt.Cursor;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.function.Function;
 
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
@@ -15,6 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.ui.JBColor;
+
+import kx.c;
 
 public class KServerDialog extends DialogWrapper {
   private final Function<String,ValidationInfo> nameValidator;
@@ -25,12 +35,43 @@ public class KServerDialog extends DialogWrapper {
   private JCheckBox useTLSCheckBox;
   private JFormattedTextField portText;
   private JTextField nameText;
+  private JButton testConnectionButton;
+  private JLabel messageLabel;
+
+  private final static Color darkGreem     = new JBColor(new Color(0, 155, 0), Color.green);
 
   public KServerDialog(Function<String,ValidationInfo> nameValidator) {
     super(null);
     this.nameValidator = nameValidator;
     init();
     setTitle("Q Server");
+    testConnectionButton.addActionListener(e -> testConnection());
+  }
+
+  private void testConnection() {
+    ValidationInfo validationInfo = doValidate();
+    if (validationInfo != null) {
+      clickDefaultButton();
+      return;
+    }
+
+    Cursor cursor = panel.getCursor();
+    try {
+      panel.setCursor(Cursor.getPredefinedCursor(WAIT_CURSOR));
+      c connection = getConnectionSpec().createConnection();
+      try {
+        messageLabel.setForeground(darkGreem);
+        messageLabel.setText("Success");
+      }
+      finally {
+        connection.close();
+      }
+    } catch (c.KException | IOException e) {
+      messageLabel.setForeground(JBColor.RED);
+      messageLabel.setText(e.getMessage());
+    } finally {
+      panel.setCursor(cursor);
+    }
   }
 
   @Nullable

--- a/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
+++ b/src/main/java/com/appian/intellij/k/settings/KServerDialog.java
@@ -20,6 +20,9 @@ import javax.swing.text.NumberFormatter;
 
 import org.jetbrains.annotations.Nullable;
 
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.progress.ProgressIndicatorProvider;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.JBColor;
@@ -54,10 +57,18 @@ public class KServerDialog extends DialogWrapper {
       clickDefaultButton();
       return;
     }
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(() -> ProgressManager.getInstance().runInReadActionWithWriteActionPriority(
+            this::doTestConnection, ProgressIndicatorProvider.getGlobalProgressIndicator()));
 
+  }
+
+  private void doTestConnection() {
     Cursor cursor = panel.getCursor();
     try {
       panel.setCursor(Cursor.getPredefinedCursor(WAIT_CURSOR));
+      messageLabel.setForeground(Color.PINK);
+      messageLabel.setText("Connecting...");
       c connection = getConnectionSpec().createConnection();
       try {
         messageLabel.setForeground(DARK_GREEN);

--- a/src/main/java/com/appian/intellij/k/settings/KServerSpec.java
+++ b/src/main/java/com/appian/intellij/k/settings/KServerSpec.java
@@ -1,8 +1,13 @@
 package com.appian.intellij.k.settings;
 
+import java.io.IOException;
 import java.util.Objects;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.intellij.util.xmlb.annotations.Transient;
+
+import kx.c;
 
 public class KServerSpec {
   private String name;
@@ -99,5 +104,10 @@ public class KServerSpec {
     KServerSpec that = (KServerSpec)o;
     return Objects.equals(name, that.name) && port == that.port && useTLS == that.useTLS && host.equals(that.host) &&
         Objects.equals(user, that.user) && Objects.equals(password, that.password);
+  }
+
+  @NotNull
+  public c createConnection() throws c.KException, IOException {
+    return new c(getHost(), getPort(), getUser() + ":" + getPassword(), useTLS());
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -203,12 +203,12 @@
     <!-- editor popup menu customization -->
     <group id="com.appian.intellij.k.actions.KRunSelectionActionGroup"
            class="com.appian.intellij.k.actions.KRunSelectionActionGroup"
-           text="Run Selection On" popup="true">
+           text="Evaluate Selection On" popup="true">
       <add-to-group group-id="EditorPopupMenu" anchor="before" relative-to-action="EditorPopupMenu1"/>
     </group>
     <group id="com.appian.intellij.k.actions.KDefineElementActionGroup"
            class="com.appian.intellij.k.actions.KDefineElementActionGroup"
-           text="Define On" popup="true">
+           text="Redefine On" popup="true">
       <add-to-group group-id="EditorPopupMenu" anchor="before" relative-to-action="EditorPopupMenu1"/>
     </group>
     <!-- end editor popup menu customization -->
@@ -216,7 +216,7 @@
     <!-- structure view popup menu customization -->
     <group id="com.appian.intellij.k.actions.KDefineNavigatableElementActionGroup"
            class="com.appian.intellij.k.actions.KDefineElementActionGroup"
-           text="Define On" popup="true">
+           text="Redefine On" popup="true">
 <!--      <separator/>-->
       <add-to-group group-id="StructureViewPopupMenu" anchor="after" relative-to-action="AddToFavorites"/>
     </group>


### PR DESCRIPTION
@a2ndrade 

1. Added 'Test Connection' button to the server dialog
2. Q requests are executed in the background thread so that GUI is not blocked for the duration of a long query (e.g. if q instance is busy)