### PR TITLE
No longer flags Q-sql column declarations as unused.

### DIFF
--- a/src/main/java/com/appian/intellij/k/psi/impl/KNamedElementImpl.java
+++ b/src/main/java/com/appian/intellij/k/psi/impl/KNamedElementImpl.java
@@ -148,7 +148,7 @@ public abstract class KNamedElementImpl extends KAstWrapperPsiElement implements
     return isQSqlColumnDeclaration() || isLiteralColumnDeclaration();
   }
 
-  private Boolean isLiteralColumnDeclaration() {
+  private boolean isLiteralColumnDeclaration() {
     return Optional.of(getParent())
     .filter(KAssignment.class::isInstance)
     .map(PsiElement::getParent)
@@ -165,7 +165,7 @@ public abstract class KNamedElementImpl extends KAstWrapperPsiElement implements
     .orElse(false);
   }
 
-  private Boolean isQSqlColumnDeclaration() {
+  private boolean isQSqlColumnDeclaration() {
     return Optional.of(getParent())
         .filter(KAssignment.class::isInstance)
         .map(PsiElement::getParent)

--- a/src/main/java/com/appian/intellij/k/psi/impl/KNamedElementImpl.java
+++ b/src/main/java/com/appian/intellij/k/psi/impl/KNamedElementImpl.java
@@ -19,6 +19,7 @@ import com.appian.intellij.k.psi.KGroupOrList;
 import com.appian.intellij.k.psi.KLambdaParams;
 import com.appian.intellij.k.psi.KNamedElement;
 import com.appian.intellij.k.psi.KNamespaceDeclaration;
+import com.appian.intellij.k.psi.KQSql;
 import com.appian.intellij.k.psi.KUserId;
 import com.appian.intellij.k.settings.KSettingsService;
 import com.intellij.lang.ASTNode;
@@ -144,19 +145,32 @@ public abstract class KNamedElementImpl extends KAstWrapperPsiElement implements
   }
 
   public boolean isColumnDeclaration() {
+    return isQSqlColumnDeclaration() || isLiteralColumnDeclaration();
+  }
+
+  private Boolean isLiteralColumnDeclaration() {
+    return Optional.of(getParent())
+    .filter(KAssignment.class::isInstance)
+    .map(PsiElement::getParent)
+    .map(PsiElement::getParent)
+    .filter(KGroupOrList.class::isInstance)
+    .map(KGroupOrList.class::cast)
+    .map(group -> {
+      // it needs at list two items to be a table e.g. ([] a:...)
+      if (group.getExpressionList().isEmpty()) {
+        return false;
+      }
+      return !group.getExpressionList().get(0).getArgsList().isEmpty();
+    })
+    .orElse(false);
+  }
+
+  private Boolean isQSqlColumnDeclaration() {
     return Optional.of(getParent())
         .filter(KAssignment.class::isInstance)
         .map(PsiElement::getParent)
         .map(PsiElement::getParent)
-        .filter(KGroupOrList.class::isInstance)
-        .map(KGroupOrList.class::cast)
-        .map(group -> {
-          // it needs at list two items to be a table e.g. ([] a:...)
-          if (group.getExpressionList().isEmpty()) {
-            return false;
-          }
-          return !group.getExpressionList().get(0).getArgsList().isEmpty();
-        })
+        .map(KQSql.class::isInstance)
         .orElse(false);
   }
 

--- a/src/test/java/com/appian/intellij/k/CompletionTest.java
+++ b/src/test/java/com/appian/intellij/k/CompletionTest.java
@@ -3,9 +3,9 @@ package com.appian.intellij.k;
 import java.util.List;
 
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 
-public class CompletionTest extends LightCodeInsightFixtureTestCase {
+public class CompletionTest extends BasePlatformTestCase {
   @Override
   protected void setUp() throws Exception {
     super.setUp();

--- a/src/test/java/com/appian/intellij/k/HighlightingTest.java
+++ b/src/test/java/com/appian/intellij/k/HighlightingTest.java
@@ -1,0 +1,37 @@
+package com.appian.intellij.k;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.List;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+public class HighlightingTest extends BasePlatformTestCase {
+  public void testUnusedArg() {
+    testHighlighting("f:{[t] 1+2 }", "t");
+  }
+
+  public void testUnusedLocal() {
+    testHighlighting("f:{[t] a:1+2; t*2 }", "a");
+  }
+
+  public void testQSqlColumnDeclaration() {
+    // column c should not be highlighted as unused
+    testHighlighting("f: {[t] update c:c1%c2 from t }");
+  }
+
+  public void testLiteralColumnDeclaration() {
+    // column c should not be highlighted as unused
+    testHighlighting("f: {a:([] c: 1 2 3); select from a}");
+  }
+
+  private void testHighlighting(String text, String... expected) {
+    myFixture.configureByText("dummy.q", text);
+    List<HighlightInfo> highlightInfos = myFixture.doHighlighting();
+
+    String[] highlights = highlightInfos.stream().map(HighlightInfo::getText).toArray(String[]::new);
+
+    assertArrayEquals(expected, highlights);
+  }
+}


### PR DESCRIPTION
@a2ndrade - this seems to fix the issue I was seeing with Q-sql columns being highlighted as unused.