### PR TITLE
Intellij 2020.03 support + updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This plugin supports q/k4 syntax. Features include:
 - Go to symbol
 - Color settings
 - Code folding
+- Remote code evaluation
+- Remote function/global definition
+- Custom authentication to remote Q instances
 
 ## Installation
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ intellij {
   buildSearchableOptions.enabled = false
 }
 
-version '1.26' // Plugin version
+version '1.27' // Plugin version
 patchPluginXml {
-  untilBuild '202.*'
+  untilBuild '203.*'
 }
 
 grammarKit {


### PR DESCRIPTION
@a2ndrade - gradle.build update to allow installing on intellij 2020.03.